### PR TITLE
fix deprications

### DIFF
--- a/lib/htmltoword/document.rb
+++ b/lib/htmltoword/document.rb
@@ -1,3 +1,5 @@
+require 'open-uri'
+
 module Htmltoword
   class Document
     include XSLTHelper
@@ -115,11 +117,11 @@ module Htmltoword
               out.put_next_entry("word/media/#{hash[:filename]}")
               begin
                 uri = hash[:url].sub %r{^file://}, ''
-                open uri, 'rb' do |f|
+                URI.open(uri, 'rb') do |f|
                   out.write(f.read)
                 end
               rescue
-                open ::Htmltoword.config.no_image_path, 'rb' do |f|
+                URI.open(::Htmltoword.config.no_image_path, 'rb') do |f|
                   out.write(f.read)
                 end
               end


### PR DESCRIPTION
```
/home/oleg/.rbenv/versions/2.7.4/lib64/ruby/gems/2.7.0/bundler/gems/htmltoword-85f2fa64faa5/lib/htmltoword/document.rb:118: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
/home/oleg/.rbenv/versions/2.7.4/lib64/ruby/gems/2.7.0/bundler/gems/htmltoword-85f2fa64faa5/lib/htmltoword/document.rb:118: warning: calling URI.open via Kernel#open is deprecated, call URI.open directly or use URI#open
```